### PR TITLE
Allow to override ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ https://docs.weblate.org/en/latest/admin/deployments.html#docker
     version: '3'
     services:
       weblate:
+        ports:
+          - 80:8080
         environment:
           - WEBLATE_EMAIL_HOST=smtp.example.com
           - WEBLATE_EMAIL_HOST_USER=user

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,6 @@ version: '3'
 services:
   weblate:
     image: weblate/weblate
-    ports:
-      - 80:8080
     volumes:
       - weblate-data:/app/data
     env_file:


### PR DESCRIPTION
The ports definition in override allows only to extend the existing
ports values. So if ports in defined in the base configuration, it is
not possible to change it.

fix #6