### PR TITLE
add WEBLATE_IP_PROXY_HEADER

### DIFF
--- a/docker-compose-https.yml
+++ b/docker-compose-https.yml
@@ -12,6 +12,7 @@ services:
       - cache
     environment:
       WEBLATE_ENABLE_HTTPS: 1
+      WEBLATE_IP_PROXY_HEADER: HTTP_X_FORWARDED_FOR
   database:
     image: postgres:9.6-alpine
     env_file:


### PR DESCRIPTION
Without this setting, weblate would assume the docker internal IP
for all requests, and could lock out everybody when somebody
tried to brute force a password, since everybody shared the
same IP in weblate's eyes.