### PR TITLE
Downgrade compose file version to 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ https://docs.weblate.org/en/latest/admin/install/docker.html
 1. Create a `docker-compose.override.yml` file with your settings.
 
     ```yml
-    version: '2'
+    version: '2.2'
     services:
       weblate:
         ports:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ https://docs.weblate.org/en/latest/admin/install/docker.html
 1. Create a `docker-compose.override.yml` file with your settings.
 
     ```yml
-    version: '3'
+    version: '2'
     services:
       weblate:
         ports:

--- a/docker-compose-https.yml
+++ b/docker-compose-https.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '2'
 services:
   weblate:
     image: weblate/weblate

--- a/docker-compose-https.yml
+++ b/docker-compose-https.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.2'
 services:
   weblate:
     image: weblate/weblate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '2'
 services:
   weblate:
     image: weblate/weblate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.2'
 services:
   weblate:
     image: weblate/weblate

--- a/test.sh
+++ b/test.sh
@@ -10,7 +10,7 @@
 # test them.
 
 cat >>docker-compose.override.yml <<EOT
-version: '3'
+version: '2'
 services:
   weblate:
     environment:

--- a/test.sh
+++ b/test.sh
@@ -10,7 +10,7 @@
 # test them.
 
 cat >>docker-compose.override.yml <<EOT
-version: '2'
+version: '2.2'
 services:
   weblate:
     environment:


### PR DESCRIPTION
For us CentOS 7 users, docker shipped in CentOS-Extras is 1.13, and docker-compose shipped in EPEL is 1.18, that gives us a maximum compose file version of [2.2](https://github.com/docker/compose/releases/tag/1.18.0).

Fortunately, the compose file used none of the newer feature or syntax. Simply downgrading the compose file version will work.

This change will make the compose file work out-of-the-box on CentOS 7. Meanwhile it should still work on newer docker and compose version.

(Online editing limited to one file per commit, please squash and use the first message.)