### PR TITLE
fix: test.sh appending docker-compose.override.yml

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -9,7 +9,7 @@
 # Execute in docker-compose.yml directory, it will create containers and
 # test them.
 
-cat >>docker-compose.override.yml <<EOT
+[ ! -f docker-compose.override.yml ] && cat >>docker-compose.override.yml <<EOT
 version: '3'
 services:
   weblate:

--- a/test.sh
+++ b/test.sh
@@ -9,7 +9,7 @@
 # Execute in docker-compose.yml directory, it will create containers and
 # test them.
 
-[ ! -f docker-compose.override.yml ] && cat >>docker-compose.override.yml <<EOT
+cat > docker-compose.override.yml <<EOT
 version: '3'
 services:
   weblate:


### PR DESCRIPTION
This patches [`test.sh`](https://github.com/WeblateOrg/docker-compose/blob/0422c5b24e6590008e7e5656aa20202192904414/test.sh) to prevent redundantly appending to the `docker-compose.override.yml`.

> **Note**: I am not sure how this affects the intent of the test case and welcome any suggestions necessary to preserve it.