### PR TITLE
fix: Early error when docker-compose is missing

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -9,7 +9,10 @@
 # Execute in docker-compose.yml directory, it will create containers and
 # test them.
 
-[ ! -x docker-compose ] && (echo "Install docker first" >&2;) && exit 1;
+if [[ ! -x `which docker-compose` ]] ; then
+    echo "Install docker first" >&2;
+    exit 1;
+fi
 
 cat > docker-compose.override.yml <<EOT
 version: '3'

--- a/test.sh
+++ b/test.sh
@@ -9,6 +9,8 @@
 # Execute in docker-compose.yml directory, it will create containers and
 # test them.
 
+[ ! -x docker-compose ] && (echo "Install docker first" >&2;) && exit 1;
+
 cat > docker-compose.override.yml <<EOT
 version: '3'
 services:


### PR DESCRIPTION
Running `test.sh` without `docker-compose` causes partial execution of the script before exiting without clear error. This patches [`test.sh`](https://github.com/WeblateOrg/docker-compose/blob/549702a18abed23ed0a5a9d6dedc4132b11d2fd5/test.sh) to early error when `docker-compose` is not executable.

> **Note**: I am not sure how this affects the intent of the test case and welcome any suggestions necessary to preserve it — Please feel free to make appropriate changes 👍 