### PR TITLE
compose: remove read-only for https-portal

### DIFF
--- a/docker-compose-https.yml
+++ b/docker-compose-https.yml
@@ -38,7 +38,6 @@ services:
     - 80:80
     - 443:443
     restart: always
-    read_only: true
     environment:
       STAGE: production
       PROXY_READ_TIMEOUT: 3600


### PR DESCRIPTION
This is caused by #198

Use the read-only flag we cannot start the containers up, https-portal fails with the following error:
  s6-overlay-preinit: fatal: unable to mkdir /var/run/s6: Read-only file system

Removing it we now get:
  weblate-docker-https-portal-1  | [s6-init] making user provided files available at /var/run/s6/etc...exited 0.

and everything is working correctly.