### PR TITLE
chore: Add .env to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /docker-compose.override.yml
+/.env
 /.venv


### PR DESCRIPTION
This change helps users to securely set sensitive environment variables such as [`WEBLATE_ADMIN_PASSWORD`](https://docs.weblate.org/en/latest/admin/install/docker.html#envvar-WEBLATE_ADMIN_PASSWORD) in the docker-compose context.
Since `docker-compose.override.yml` is already excluded from gitignore, there's no security concern whatsoever; however, placing `.env` in the project root is supported by [Docker](https://docs.docker.com/compose/how-tos/environment-variables/set-environment-variables/) and widely adopted by the community. Some users may find it handy to follow this practice, and it also works well with other solutions such as [dotenv.org](https://www.dotenv.org/docs/). 