### PR TITLE
fix: CELERY_SINGLE_PROCESS in single process example

### DIFF
--- a/docker-compose-single-celery.yml
+++ b/docker-compose-single-celery.yml
@@ -22,7 +22,7 @@ services:
     - weblate-data:/app/data
     - weblate-cache:/app/cache
     environment:
-      SINGLE_CELERY_PROCESS: 1
+      CELERY_SINGLE_PROCESS: 1
     env_file:
     - ./environment
     restart: always


### PR DESCRIPTION
Somehow, this has gone completely unnoticed. I was wondering why this flag was doing nothing at all.

The env var in the single-celery example is wrong. This PR replaces it with the correct one.